### PR TITLE
Fix NullPointerException with getHitTestResult() on destroy

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -424,6 +424,16 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
         return true;
     }
 
+    // getHitTestResult() can throw a NullPointerException if the underlying AwContents of Chromium has already
+    // been destroyed but the View is still receiving focus events (e.g. focus dispatched during teardown).
+    private @Nullable HitTestResult safeGetHitTestResult() {
+      try {
+        return this.getHitTestResult();
+      } catch (NullPointerException e) {
+        return null;
+      }
+    }
+
     @Override
     public boolean requestFocus(int direction, Rect previouslyFocusedRect) {
       // Only accept the focus if a focusable element inside the WebView's content has been touched.
@@ -431,8 +441,8 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
       // result of the hit test, but it may be non-exhaustive. Also getHitTestResult() may return
       // a stale result, but that's not a problem as a touch will repeat the requestFocus() call,
       // and it will get an up-to-date hit result in that next call.
-      HitTestResult hit = this.getHitTestResult();
-      if (hit.getType() == HitTestResult.EDIT_TEXT_TYPE) {
+      HitTestResult hit = safeGetHitTestResult();
+      if (hit != null && hit.getType() == HitTestResult.EDIT_TEXT_TYPE) {
         return super.requestFocus(direction, previouslyFocusedRect);
       } else return false;
     }
@@ -444,8 +454,8 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
         // If the last hit test in WebView matched an input field, we must reset it on blurring
         // to avoid that stale hit test result to be reused by requestFocus() when the component
         // is clicked again. There is a slim
-        HitTestResult hit = this.getHitTestResult();
-        if (hit.getType() == HitTestResult.EDIT_TEXT_TYPE) {
+        HitTestResult hit = safeGetHitTestResult();
+        if (hit != null && hit.getType() == HitTestResult.EDIT_TEXT_TYPE) {
           long now = SystemClock.uptimeMillis();
 
           // There is a slim chance that our reset does not work, if our emulated off-viewport


### PR DESCRIPTION
### Summary

`RNCWebView.requestFocus()` and `RNCWebView.onFocusChanged()` both call`this.getHitTestResult()` and immediately dereference the result. We see crashes where a NullPointerException is thrown from `WebViewChromium.getHitTestResult()`.
https://github.com/digitalfabrik/integreat-app/pull/4216

```
Caused by: java.lang.NullPointerException: Attempt to read from field
'int WV.bh.a' on a null object reference in method
'android.webkit.WebView$HitTestResult com.android.webview.chromium.WebViewChromium.getHitTestResult()'
at com.android.webview.chromium.WebViewChromium.getHitTestResult(...)
at android.webkit.WebView.getHitTestResult(WebView.java:1231)
at com.reactnativecommunity.webview.RNCWebView.requestFocus(RNCWebView.java:434)
```

The field that's null (`WV.bh.a`) is in Chromium's `AwContents` — it gets nulled out when the WebView's native peer is destroyed but the Android `View` is still in the hierarchy and can receive focus events (e.g. a focus dispatch during component teardown / fast navigation away while loading).

A simple null-check on the return value` of `getHitTestResult()` is not enough because the exception is thrown before any value is returned. This PR wraps the call in a try/catch (factored into a small `safeGetHitTestResult()`helper used at both call sites) and treats the failure as "no hit" — i.e.refuses focus instead of crashing.

### Notes

Original focus-handling override was introduced in #3575 to fix #3014.